### PR TITLE
3091 second address line

### DIFF
--- a/partials/shop-checkout-address.htm
+++ b/partials/shop-checkout-address.htm
@@ -95,7 +95,7 @@
   <div class="col-sm-12 form-group">
     <input data-mirror type="text" class="form-control disabled" name="shippingInfo[streetAddressLine1]" id="shipping_address"  value="{{ shippingInfo.streetAddressLine1 }}" placeholder="Address"/>
     <span class="error small text-danger"></span>
-    <label for="shipping_address">Address line 1</label>
+    <label for="shipping_address">Address line 1 *</label>
   </div>
   <div class="col-sm-12 form-group">
     <input data-mirror type="text" class="form-control disabled" name="shippingInfo[streetAddressLine2]" id="shipping_address"  value="{{ shippingInfo.streetAddressLine2 }}" placeholder="optional"/>

--- a/partials/shop-checkout-address.htm
+++ b/partials/shop-checkout-address.htm
@@ -27,7 +27,12 @@
   <div class="col-sm-12 form-group">
     <input data-mirror type="text" class="form-control" id="billing_address" name="billingInfo[streetAddressLine1]" value="{{ billingInfo.streetAddressLine1 }}" placeholder="123 Example Dr"/>
     <span class="error small text-danger"></span>
-    <label for="billing_address">Address *</label>
+    <label for="billing_address">Address line 1 *</label>
+  </div>
+  <div class="col-sm-12 form-group">
+    <input data-mirror type="text" class="form-control" id="billing_address" name="billingInfo[streetAddressLine2]" value="{{ billingInfo.streetAddressLine2 }}" placeholder="optional"/>
+    <span class="error small text-danger"></span>
+    <label for="billing_address">Address line 2</label>
   </div>
   <div class="col-sm-6 form-group">
     <input data-mirror type="text" class="form-control" name="billingInfo[city]" id="billing_city" value="{{ billingInfo.city }}" placeholder="Vancouver"/>
@@ -90,7 +95,12 @@
   <div class="col-sm-12 form-group">
     <input data-mirror type="text" class="form-control disabled" name="shippingInfo[streetAddressLine1]" id="shipping_address"  value="{{ shippingInfo.streetAddressLine1 }}" placeholder="Address"/>
     <span class="error small text-danger"></span>
-    <label for="shipping_address">Address *</label>
+    <label for="shipping_address">Address line 1</label>
+  </div>
+  <div class="col-sm-12 form-group">
+    <input data-mirror type="text" class="form-control disabled" name="shippingInfo[streetAddressLine2]" id="shipping_address"  value="{{ shippingInfo.streetAddressLine2 }}" placeholder="optional"/>
+    <span class="error small text-danger"></span>
+    <label for="shipping_address">Address line 2</label>
   </div>
   <div class="col-sm-6 form-group">
     <input data-mirror type="text" class="form-control disabled" name="shippingInfo[city]" id="shipping_city" value="{{ shippingInfo.city }}" placeholder="City"/>

--- a/partials/shop-customerprofile.htm
+++ b/partials/shop-customerprofile.htm
@@ -20,7 +20,13 @@
         
         <div class="col-sm-12 form-group">
           <input name="billing[street_address]" id="billing_address" type="text" class="form-control" placeholder="street address*" value="{{ billing.street_address }}"/>
-          <label for="billing_address">Address</label>
+          <label for="billing_address">Address line 1</label>
+          <span class="error"></span>
+        </div>
+
+        <div class="col-sm-12 form-group">
+          <input name="billing[street_address_line2]" id="billing_address" type="text" class="form-control" placeholder="optional" value="{{ billing.street_address_line2 }}"/>
+          <label for="billing_address">Address line 2</label>
           <span class="error"></span>
         </div>
         
@@ -99,7 +105,13 @@
 
         <div class="col-sm-12 form-group">
           <input name="shipping[street_address]" id="shipping_address" type="text" class="form-control" placeholder="street address*" value="{{ shipping.street_address }}"/>
-          <label for="shipping_address">Address</label>
+          <label for="shipping_address">Address line 1</label>
+          <span class="error"></span>
+        </div>
+
+        <div class="col-sm-12 form-group">
+          <input name="shipping[street_address_line2]" id="shipping_address" type="text" class="form-control" placeholder="optional" value="{{ shipping.street_address_line2 }}"/>
+          <label for="shipping_address">Address line 2</label>
           <span class="error"></span>
         </div>
 


### PR DESCRIPTION
### Testing Checklist

https://github.com/lemonstand/lemonstand-2/issues/3091
- [ ] address line 2 shows up in database after placing order as a guest (shop_customer_address table, street_address_line2 column)
- [ ] address line 2 shows in Orders in store backend
- [ ] address line 2 shows up for billing and shipping info in front end
- [ ] address line 2 field repopulates for logged in users and guest users (same session)
- [ ] address line 2 shows up in database when a new customer registers and their address line 2 is added from the `/profile` page
